### PR TITLE
[minor fix] Put Linux releases on separate list from MacOS

### DIFF
--- a/content/download.md
+++ b/content/download.md
@@ -16,6 +16,7 @@ draft: false
 
 * **Application Package**  
   [GB Studio-darwin-x64-1.0.0.zip](https://github.com/chrismaltby/gb-studio/releases/download/v1.0.0/GB.Studio-darwin-x64-1.0.0.zip)  
+
 ## Linux
 
 * **Ubuntu / Debian-based**  


### PR DESCRIPTION
As of right now, the Linux releases list is nested inside the MacOS releases list (as can be seen [here](https://i.imgur.com/Wdl1XEd.png)).

I believe the issue is with the lack of a simple newline character, and thus I've added it.

Cheers on the amazing project, I'm so glad I found out about it!