### PR TITLE
Overhauled music doc with GBT Player's readme info

### DIFF
--- a/content/docs/music.md
+++ b/content/docs/music.md
@@ -15,28 +15,28 @@ When done, add your MOD files to the `assets/music` folder of your project.
 
 Due to the limits of the Gameboy's hardware, there can only be 4 audio channels in a MOD file.
 
-The first two channels can make pulse waves with various widths. The third channel can make a variety of pre-set waveforms. The fourth channel generates different kinds of noise. These waveform variations are accessed through each channel's instrument parameter.
+The first two channels generate pulse waves. The pulse width can be changed by adjusting the channel's instrument parameter.
+The third channel generates a variety of pre-set waveforms. This channel's waveform is controlled by its instrument parameter.
+The fourth channel generates noise waveforms. This channel's waveform is also controlled by its instrument parameter.
 
-Channel # | Waveform | Note Range* | Inst. Range | Effects Allowed
---------- | --------- | --------- | --------- | --------- |
+Channel # | Waveform | Note Range* | Instrument Range | Effects Allowed
+---------- | ---------- | ---------- | ---------- | ----------
 Channel 1 | Pulse | C3 to B8 | 1-4 | All effects
 Channel 2 | Pulse | C3 to B8 | 1-4 | All effects
 Channel 3 | Wave | C3 to B8 | 8-15 | Only effects 0, E8 and EC
 Channel 4 | Noise | Only C5 | 16-31 | All except 0
 
-Any notes out of a channel's note range will be approximated to the closest in-range note. All notes in channel 4 are converted to C5.
-
-If a channel has notes, the instrument parameter and volume parameter should *at least* be set for the channel's first note.
-
-*This note range is for trackers that display notes between C1 and C8 such as OpenMPT. Other trackers that display notes between C0 and C7 such as MilkyTracker should read the range guidelines down an octave.
+*This note range is for trackers that display notes between C1 and C8 such as OpenMPT. Trackers that display notes between C0 and C7 such as MilkyTracker should use transpose these guidelines an octave down.
 
 ## Tempo
 
-GBT Player reads effect ``f`` as song speed. This does not translate to BPM and requires further experimentation.
+GBT Player reads effect ``f`` as song speed. ``f`` defines how many in-game frames should pass before the next tick of the MOD file is played.
 
-Effect ``f01`` is the slowest speed and effect ``f1f`` is the fastest speed. This effect can be set on any channel except channel 3. Songs without their speed set will still be readable.
+Effect ``f01`` is the fastest and plays 1 tick per frame. ``f1f`` is the slowest speed and plays 1 tick every 32 frames. This effect can be set on any channel except channel 3.
 
 ## General Tips
+
+* For newer composers, it's a good idea to test your music after creating a few patterns to identify differences between the hardware and your tracker.
 
 * To prevent notes that overlap when looping your song in-game, enter `00` as the note's volume on the tick it should stop playing.
 

--- a/content/docs/music.md
+++ b/content/docs/music.md
@@ -13,25 +13,28 @@ When done, add your MOD files to the `assets/music` folder of your project.
 
 # Important Limitations
 
-Due to the limits of the Gameboy's hardware, there can only be 4 audio channels in a MOD file. Each channel is locked to a pre-determined waveform.
+Due to the limits of the Gameboy's hardware, there can only be 4 audio channels in a MOD file.
 
-Channel # | Waveform | Range | Effects Allowed
---------- | --------- | --------- | --------- |
-Channel 1 | 33% Pulse | C2 to B7 | All effects
-Channel 2 | 33% Pulse | C2 to B7 | All effects
-Channel 3 | Low Freq. Wave | C2 to B7 | Only effects 0, E8 and EC
-Channel 4 | Noise | Only C5 | All except 0
+The first two channels can make pulse waves with various widths. The third channel can make a variety of pre-set waveforms. The fourth channel generates different kinds of noise. These waveform variations are accessed through each channel's instrument parameter.
 
-Any notes out of a channel's range will be approximated to the closest in-range note. All notes in channel 4 are converted to C5.
+Channel # | Waveform | Note Range* | Inst. Range | Effects Allowed
+--------- | --------- | --------- | --------- | --------- |
+Channel 1 | Pulse | C3 to B8 | 1-4 | All effects
+Channel 2 | Pulse | C3 to B8 | 1-4 | All effects
+Channel 3 | Wave | C3 to B8 | 8-15 | Only effects 0, E8 and EC
+Channel 4 | Noise | Only C5 | 16-31 | All except 0
 
-The instrument parameter and volume parameter should be set on *at least* every channel's first note. Any instrument number can be used, only the channel defines the waveform.
+Any notes out of a channel's note range will be approximated to the closest in-range note. All notes in channel 4 are converted to C5.
 
-These range tests were done with MilkyTracker where B7 is the highest note it can output. Other tracker software may be able to test higher notes.
+If a channel has notes, the instrument parameter and volume parameter should *at least* be set for the channel's first note.
+
+*This note range is for trackers that display notes between C1 and C8 such as OpenMPT. Other trackers that display notes between C0 and C7 such as MilkyTracker should read the range guidelines down an octave.
+
 ## Tempo
 
-GBT Player reads effect `f` as song speed. This does not translate to BPM and requires further experimentation. Songs without their speed set will still be readable.
+GBT Player reads effect ``f`` as song speed. This does not translate to BPM and requires further experimentation.
 
-Effect `f01` is the slowest speed and effect `f1f` is the fastest speed. This effect can be set on any channel except channel 3.
+Effect ``f01`` is the slowest speed and effect ``f1f`` is the fastest speed. This effect can be set on any channel except channel 3. Songs without their speed set will still be readable.
 
 ## General Tips
 
@@ -43,6 +46,6 @@ Effect `f01` is the slowest speed and effect `f1f` is the fastest speed. This ef
 30 2F 2E 2D 2C 2B 2A 29 28 27 26 25 24 23 22 21 10
 10 0F 0E 0D 0C 0B 0A 09 08 07 06 05 04 03 02 01 00`
 
-* MilkyTracker will not save MOD data correctly when making edits to existing MOD files. Using a default filetype (such as MilkyTracker's .xm) for editing and saving as .mod when you are finished prevents this.
+* MilkyTracker will not save MOD data correctly when making edits to existing MOD files. You can prevent this by savings songs as .xm and exporting to .mod when you are finished.
 
 * Check out the README and documentation of [GBT Player](https://github.com/AntonioND/gbt-player) for more on how the software works and for music theory resources.

--- a/content/docs/music.md
+++ b/content/docs/music.md
@@ -5,10 +5,44 @@ next: "/docs/build"
 nextTitle: "Building Your Game"
 ---
 
-Write your music as MOD files using software such as [OpenMPT](https://openmpt.org/) or [MilkyTracker](https://milkytracker.titandemo.org/) and add to the `assets/music` folder.
+GB Studio is internally using [GBT Player](https://github.com/AntonioND/gbt-player). Additional documentation and sample MOD files can be found in its own repository.
 
-# Requirements
+GBT Player reads and plays back MOD files. You can use software such as [OpenMPT](https://openmpt.org/) or [MilkyTracker](https://milkytracker.titandemo.org/) to export tracker music to the MOD filetype.
 
-Only four channels can be used to allow for the hardware limitations. The first two are pulse channels, the third is a wav channel and the fourth is a noise channel.
+When done, add your MOD files to the `assets/music` folder of your project.
 
-Internally GB Studio is using [GBT Player](https://github.com/AntonioND/gbt-player), additional documentation on creating music can be found in that repo along with a few more sample MOD files.
+# Important Limitations
+
+Due to the limits of the Gameboy's hardware, there can only be 4 audio channels in a MOD file. Each channel is locked to a pre-determined waveform.
+
+Channel # | Waveform | Range | Effects Allowed
+--------- | --------- | --------- | --------- |
+Channel 1 | 33% Pulse | C2 to B7 | All effects
+Channel 2 | 33% Pulse | C2 to B7 | All effects
+Channel 3 | Low Freq. Wave | C2 to B7 | Only effects 0, E8 and EC
+Channel 4 | Noise | Only C5 | All except 0
+
+Any notes out of a channel's range will be approximated to the closest in-range note. All notes in channel 4 are converted to C5.
+
+The instrument parameter and volume parameter should be set on *at least* every channel's first note. Any instrument number can be used, only the channel defines the waveform.
+
+These range tests were done with MilkyTracker where B7 is the highest note it can output. Other tracker software may be able to test higher notes.
+## Tempo
+
+GBT Player reads effect `f` as song speed. This does not translate to BPM and requires further experimentation. Songs without their speed set will still be readable.
+
+Effect `f01` is the slowest speed and effect `f1f` is the fastest speed. This effect can be set on any channel except channel 3.
+
+## General Tips
+
+* To prevent notes that overlap when looping your song in-game, enter `00` as the note's volume on the tick it should stop playing.
+
+* The maximum volume per-channel is 40 in hexadecimal. A linear transition from volume 40 to 0 looks like this:
+
+`40 3F 3E 3D 3C 3B 3A 39 38 37 36 35 34 33 32 31 30
+30 2F 2E 2D 2C 2B 2A 29 28 27 26 25 24 23 22 21 10
+10 0F 0E 0D 0C 0B 0A 09 08 07 06 05 04 03 02 01 00`
+
+* MilkyTracker will not save MOD data correctly when making edits to existing MOD files. Using a default filetype (such as MilkyTracker's .xm) for editing and saving as .mod when you are finished prevents this.
+
+* Check out the README and documentation of [GBT Player](https://github.com/AntonioND/gbt-player) for more on how the software works and for music theory resources.

--- a/content/docs/music.md
+++ b/content/docs/music.md
@@ -13,11 +13,13 @@ When done, add your MOD files to the `assets/music` folder of your project.
 
 # Important Limitations
 
-Due to the limits of the Gameboy's hardware, there can only be 4 audio channels in a MOD file.
+Due to the limits of the Gameboy's hardware, there can only be 4 channels in a MOD file.
 
-The first two channels generate pulse waves. The pulse width can be changed by adjusting the channel's instrument parameter.
-The third channel generates a variety of pre-set waveforms. This channel's waveform is controlled by its instrument parameter.
-The fourth channel generates noise waveforms. This channel's waveform is also controlled by its instrument parameter.
+The first two channels generate pulse waves. The pulse width can be changed by adjusting the channel's instrument parameter from 1 to 4.
+
+The third channel generates a variety of pre-set waveforms. You can change the waveform by setting its instrument parameter from 8 to 15.
+
+The fourth channel generates a variety of noise waveforms. You can change the waveform by setting its instrument parameter from 16 to 31.
 
 Channel # | Waveform | Note Range* | Instrument Range | Effects Allowed
 ---------- | ---------- | ---------- | ---------- | ----------
@@ -36,16 +38,10 @@ Effect ``f01`` is the fastest and plays 1 tick per frame. ``f1f`` is the slowest
 
 ## General Tips
 
-* For newer composers, it's a good idea to test your music after creating a few patterns to identify differences between the hardware and your tracker.
+* For newer composers, it's a good idea to test your music after creating a few patterns to identify any audible differences between GBT Player and your tracker.
 
 * To prevent notes that overlap when looping your song in-game, enter `00` as the note's volume on the tick it should stop playing.
 
-* The maximum volume per-channel is 40 in hexadecimal. A linear transition from volume 40 to 0 looks like this:
-
-`40 3F 3E 3D 3C 3B 3A 39 38 37 36 35 34 33 32 31 30
-30 2F 2E 2D 2C 2B 2A 29 28 27 26 25 24 23 22 21 10
-10 0F 0E 0D 0C 0B 0A 09 08 07 06 05 04 03 02 01 00`
-
 * MilkyTracker will not save MOD data correctly when making edits to existing MOD files. You can prevent this by savings songs as .xm and exporting to .mod when you are finished.
 
-* Check out the README and documentation of [GBT Player](https://github.com/AntonioND/gbt-player) for more on how the software works and for music theory resources.
+* Check out the README and documentation of [GBT Player](https://github.com/AntonioND/gbt-player) for more on how the software works.


### PR DESCRIPTION
In this edit I go over the limits of GBT Player when it reads MOD files, and things it depends on for every MOD file.

I tested the range of the first 3 channels, using GB Studio's emulator along with mGBA to ensure these notes were still playable on emulated hardware. They are not limited to C3 like GBT's documentation says, but more investigation should still take place with note ranges.