### PR TITLE
put important info near the top, added tutorial links, added section on speed

### DIFF
--- a/content/docs/music.md
+++ b/content/docs/music.md
@@ -7,103 +7,113 @@ nextTitle: "Building Your Game"
 
 GB Studio is internally using [GBT Player](https://github.com/AntonioND/gbt-player) *(GameBoy Tracker)*. Additional documentation and sample MOD files can be found in its own repository.
 
-GBT Player reads and plays back .MOD files. You can use software such as [OpenMPT](https://openmpt.org/) or [MilkyTracker](https://milkytracker.titandemo.org/) to create .MOD tracker music. Of course, you can use other software that can edit .mod files (like [BassoonTracker](https://www.stef.be/bassoontracker/), [ProTracker](https://16-bits.org/pt.php), etc.)
+If you're unfamiliar with making tracker music, you can follow a video series like [Y_VE_Squared's OpenMPT tutorial](https://youtu.be/2jRh_XNMYE0), [Gruber's MilkyTracker tutorial](https://youtu.be/DRDlix-KT1E?list=PLur95ujyAigtzAa6Rw_VcIgdP4n45JvZh), [wasp amiga's ProTracker tutorial](https://youtu.be/S1yE2qL8UcY?list=PLVoRT-Mqwas9gvmCRtOusCQSKNQNf6lTc) and many others. These videos cover how to navigate a tracker program and are well-designed for tracker beginners.
 
-# How do I start?
+For Windows and Linux (WINE) users, [OpenMPT](https://openmpt.org/) has the fewest workarounds for creating .mod files for use in GBT Player. For OS X, [MilkyTracker](https://milkytracker.titandemo.org/), [8bitbubsy's ProTracker/Fasttracker Clones](https://16-bits.org/pt.php) and the browser-based [BassoonTracker](https://www.stef.be/bassoontracker/) all export .mod files and will work with GBT Player.
 
-GameBoy music is made using a tracker, a *computer music* oriented program.
+# Getting Started
 
-1. Download a tracker (recommended [OpenMPT](https://openmpt.org/))
-2. In a blank Gbstudio project, find the file `assets/music/template.mod` and open it with your tracker.\
- **You must edit this file for the right GameBoy instruments.**
-3. Start deleting notes from the song (some trackers support drag selection).
-4. Select your instument and press letter keys on the keyboard to make notes.
-5. Read your trackers documentation, and find tutorials on using trackers in general.
-6. Keep testing your song.mod in the GBstudio emulator, as it will always sound different.
+1. Create a blank GB Studio project, find the file `assets/music/template.mod` and open it with your tracker.
+ - You must edit this file to hear accurate Gameboy instruments in your tracker.
+ - MilkyTracker users should save this file as an .xm file. Saving a .mod file in MilkyTracker will corrupt it. Export your song as a .mod file every time you want to test your song in-game.
+2. Keeping the instrument data, delete/modify template.mod's song data.
+3. Use the instrument list shown later in this document to pick the sounds you want. Changing the samples in your tracker will **not** affect how they sound in-game.
 
-When done, add your MOD files to the `assets/music` folder of your project.
-
-## How to use a tracker
-Once you add notes using the letter keys, you should see\
-`D-5 01 ---` in your tracker.\
-That's the **note**, **instrument**, and **effect**.\
-`C` is the volume effect,\
-Change `---` to `C40` for loud, and `C00` to mute, or any [hexadecimal](https://www.mathsisfun.com/hexadecimals.html) inbetween.\
-Most trackers use the arrow keys for navigation.\
-There are 64 notes per pattern, but you can keep adding more patterns.
-
-#### My notes sound wrong!
-Make sure you are using the right instruments for each channel, a list is below.\
-Unlike your tracker, GBT Player will not automaticly reset the volume on notes, so use C volume effect on new notes.
+When done, add your MOD files to the `assets/music` folder of your project. Test your song in-game often to keep track of any audible in-game differences.
 
 # Important Limitations
 
-Due to the limits of the Gameboy's hardware, there can only be 4 channels in the .MOD file. 
+The .mod filetype only allows 4 channels of audio. For GBT Player, each channel has its own limits when composing.
 
 | Channel # | Sound | Note Range* | Instrument Range | Effects Allowed       |
 | --------- | ----- | ----------- | ---------------- | --------------------- |
-| Channel 1 | Pulse | C3 to B8    | 1-4              | 0, B, C, D, E8, EC, F |
-| Channel 2 | Pulse | C3 to B8    | 1-4              | 0, B, C, D, E8, EC, F |
+| Channel 1 | Pulse | C3 to B8    | 1-4              | All listed effects    |
+| Channel 2 | Pulse | C3 to B8    | 1-4              | All listed effects    |
 | Channel 3 | Wave  | C3 to B8    | 8-15             | 0, E8 and EC          |
-| Channel 4 | Noise | Only C5     | 16-31            | B, C, D, EC, E8, F    |
+| Channel 4 | Noise | Only C5     | 16-31            | B, C, D, EC, E8 and F |
 
 **This note range is for trackers that display notes between C1 and C8 such as OpenMPT. Trackers that display notes between C0 and C7 such as MilkyTracker should use transpose these guidelines an octave down (as in, C3 to B8 in MilkyTracker becomes C2 to B7).*
 
-# Instruments available
+- Your song's tempo will not be present in-game unless set via the `F` effect on channels 1, 2 and 4.
+- You cannot have more than 64 notes per-channel in a pattern. Patterns less than 64 notes need to use effect `B`, listed in this document's effect list.
+- Channel 1 needs to either start with a note or it needs its effect parameter set to `C00`.
+- Channel 3 always needs its instrument set even if only the volume is being changed.
+- Instrument envelopes will not be heard in-game.
+- If working in .xm, the volume parameter will overwrite the effect parameter with Cxx
 
-The pulse channels get 4 instruments (from 1 to 4): 
+# Instrument List
 
-- 25% pulse
-- 50% pulse (sometimes called a square wave)
-- 75% pulse (inverted 25% pulse)
-- 12.5% pulse
+These instruments are listed by their hexadecimal numbers.
 
-The wave channel gets 8 instruments (from 8 to 15):
+The pulse channels use 4 instruments from 1 to 4:
 
-- Buzzy 
-- Ringy (useful for SFX)
-- Sync Saw
-- Ring Saw
-- Octave Pulse + Triangle
-- Sawtooth
-- Square
-- Sine
+| *#* | *Waveform* |
+| --- | ------------------------------ |
+| **1.** | 25% pulse |
+| **2.** | 50% pulse (square wave) |
+| **3.** | 75% pulse (inverted 25% pulse) |
+| **4.** | 12.5% pulse |
 
-The noise channels gets the most instruments, but that's also because of how the noise works on the Gameboy:
+The wave channel uses 8 instruments from 8 to F in hexadecimal:
 
-- 16 to 23 - Periodic (looped) noise at various pitches
-- 24 to 32 - Pseudorandom noise at various pitches
+| *#* | *Waveform* |
+| --- | ---------------------- |
+| **8.** | Buzzy |
+| **9.** | Ringy Buzz |
+| **A.** | Sync Saw |
+| **B.** | Ring Saw |
+| **C.** | Octave Pulse + Triangle |
+| **D.** | Sawtooth |
+| **E.** | Square |
+| **F.** | Sine |
 
-## Effects
+The noise channel uses 16 instruments from 10 in hexadecimal to 20 in hexadecimal:
+
+| *Inst. Range* | *Waveforms* |
+| ------------ | ------------------------------------------- |
+| **10hx** to **17hx** | Periodic (looped) noise at various pitches |
+| **18hx** to **20hx** | Pseudorandom noise at various pitches |
+
+## Tempo/Speed
+
+Project tempo is not carried over to GBT Player. Effect ``F`` is read as your song's speed. ``F`` defines how many in-game frames should pass before the next note of the .mod file is played. ``F01`` is the fastest speed and plays 1 tick every frame. ``F1F`` is the slowest speed and plays 1 tick every 32 frames. All trackers are compatible with this effect and they will change the project's speed to match effect ``F``.
+
+For faster speed settings between ``F01`` and ``F04`` the Project BPM should be set to 150 BPM to emulate the Gameboy's refresh rate. This data is only read in the tracker software and can be adjusted if needed.
+
+Effect ``F`` can be set on any channel except channel 3. Channels 2 or 4 are best used to set speed since channel 1 will automatically start the song by playing at full volume unless it has effect ``C00`` added to silence it.
+
+## Volume Limitations
+
+Channel 4 has full volume range from 0 to 40 in hexadecimal. Channel 3 will only display volume changes of `00, 10, 20` and `40`.
+
+Channels 1 and 2 only have a quarter of the full volume range, and only volume changes in steps of 4 are registered. Here are all the volumes they will register in hexadecimal:
+
+`0, 4, 8, C, 10, 14, 18, 1C, 20, 24, 28, 2C, 30, 34, 38, 3C, 40`
+
+## Full List of Effects
 
 | EFFECT  |     NAME      | NOTES                                                        |
 | :-----: | :-----------: | :----------------------------------------------------------- |
-| **0xy** |   Arpeggio    | Where x = 2nd note, y = 3rd note, in semitones. You should set the instrument when using this effect. |
-| **Bxx** |     Jump      | Jump to specific pattern `xx`.                               |
-| **Cxx** |    Volume     | Sets the volume to xx. Valid values are from `00` to `40`. The wave channel can only be set to `00, 10, 20` and `40`. The pulse channels only have a quarter of the range. You should use a volume effect on each new note to reset their volumes post-conversion to reset the volume. |
+| **0xy** |   Arpeggio    | Plays 3 notes rapidly. x and y's values represent # of semitones above the original note. x is for the 2nd note, y is for the 3rd note. You should set the instrument when using this effect. |
+| **Bxx** |     Jump      | Jump to specific pattern `xx`. Put this on the last heard note of a pattern. |
+| **Cxx** |    Volume     | Set the volume of a note to xx from `00` to `40`. A volume effect should be set on each new note since note volume is not reset in-game unlike most trackers' global volume setting. |
 | **Dxx** | Pattern break | Jumps to the next pattern early, where `xx` is the position (row) it should jump to in the next pattern. |
-| **E8x** |      Pan      | Set the panning to `x`. `0-3` = Hard Left, `4-B` = Centre, `C-F` = Hard Right |
-| **ECx** |   Note cut    | Cut the note after `x` ticks. `0 < x < speed-1`              |
-| **Fxx** |   Set speed   | Sets the song speed to `xx`. Valid values are `01` to `1F`. The value represents how many frames should the song wait before moving on to another row. Setting BPM speed has no effect after conversion. |
+| **E8x** |      Pan      | Set the panning to `x`. `0-3` = Hard Left, `4-B` = Center, `C-F` = Hard Right |
+| **ECx** |   Note cut    | Cut the note after `x` ticks. `0 < x < speed-1` |
+| **Fxx** |   Set speed   | Sets the song speed to `xx`. Valid values are `01` to `1F`. The value represents how many frames the game should wait before moving on to the next note of the song. |
 
 ## General Tips
 
-- It's a good idea to test your music after creating a few patterns to identify any audible differences between GBT Player and your tracker. Things are not always 1:1.
+- Test your music after creating a few patterns to identify any audible differences between GBT Player and your tracker.
 - Read the manuals and tutorials for [OpenMPT](https://wiki.openmpt.org/Tutorial:_Getting_Started) or [MilkyTracker](https://milkytracker.titandemo.org/docs/MilkyTracker.html).
 - If you're using OpenMPT, make sure to disable ProTracker 1/2 mode and Amiga frequency limits in the song settings! The latter is especially important to disable, as leaving it enabled will limit your pitch range from C4 to B6.
-- You might want to set the song BPM to 150 (either via song settings, or effects in OpenMPT). It will more closely match the conversion in terms of speed.
-- You should set the volume and the instrument for each new note.
-- You should set the instrument upon a volume change on the wave channel.
 - To prevent notes that overlap when looping your song in-game, enter `00` as the note's volume on the tick it should stop playing.
-- If you're not using the pulse channels right as the song starts, it is a wise idea to mute them using a C00 effect. They sometimes start out by playing garbled notes, even if there's nothing present on those channels.
-- You may notice that the channels, when previewing your song within your tracker, will be already panned left and right. This is a limitation of the .MOD file format itself and it isn't something you can change. The default panning will not be present upon conversion, unless set by yourself via effects (more info below).
-- MilkyTracker will not save .MOD data correctly when making edits to existing .MOD files. One way to prevent this is by saving drafts as an .xm file (which Milky natively supports), and exporting the song as a .mod when you need to try it in GB Studio.
+- If you're not using the first pulse channel right as the song starts, mute it using a C00 effect.
 - Check out the README and documentation of [GBT Player](https://github.com/AntonioND/gbt-player) for more on how the software works.
 
 #### OpenMPT Keyboard shortcuts: For the default keyboard layout.
-Change the selected note, instrument, or effect, value using\
-`Crtl +`, `Crtl -` or `Crtl & Scroll wheel`\
-Change your curent instument using `CRTL & Arrow Up or Down`\
-Move between patterns with `CRTL & Arrow Left or Right`\
-`F5` Play the song from here, `F6` Play the song from the begining.\
-*Note There are 4 play buttons, 2 for the song, and 2 that loop the pattern.
+Change the selected note, instrument, or effect, value using `Crtl +`, `Crtl -` or `Crtl & Scroll wheel`
+
+Change your current instrument using `CRTL & Arrow Up or Down`
+
+Move between patterns with `CRTL & Arrow Left or Right`

--- a/content/docs/music.md
+++ b/content/docs/music.md
@@ -9,7 +9,7 @@ GB Studio is internally using [GBT Player](https://github.com/AntonioND/gbt-play
 
 If you're unfamiliar with making tracker music, you can follow a video series like [Y_VE_Squared's OpenMPT tutorial](https://youtu.be/2jRh_XNMYE0), [Gruber's MilkyTracker tutorial](https://youtu.be/DRDlix-KT1E?list=PLur95ujyAigtzAa6Rw_VcIgdP4n45JvZh), [wasp amiga's ProTracker tutorial](https://youtu.be/S1yE2qL8UcY?list=PLVoRT-Mqwas9gvmCRtOusCQSKNQNf6lTc) and many others. These videos cover how to navigate a tracker program and are well-designed for tracker beginners.
 
-For Windows and Linux (WINE) users, [OpenMPT](https://openmpt.org/) has the fewest workarounds for creating .mod files for use in GBT Player. For OS X, [MilkyTracker](https://milkytracker.titandemo.org/), [8bitbubsy's ProTracker/Fasttracker Clones](https://16-bits.org/pt.php) and the browser-based [BassoonTracker](https://www.stef.be/bassoontracker/) all export .mod files and will work with GBT Player.
+For Windows and Linux (WINE) users, [OpenMPT](https://openmpt.org/) is the most functional of the trackers for loading and creating .mod files. Alternatively, [MilkyTracker](https://milkytracker.titandemo.org/), [8bitbubsy's ProTracker/FastTracker II Clones](https://16-bits.org/pt.php) and the browser-based [BassoonTracker](https://www.stef.be/bassoontracker/) work on all platforms and can be used to create .mod files for GBT Player.
 
 # Getting Started
 

--- a/content/docs/music.md
+++ b/content/docs/music.md
@@ -94,7 +94,7 @@ Channels 1 and 2 only have a quarter of the full volume range, and only volume c
 
 | EFFECT  |     NAME      | NOTES                                                        |
 | :-----: | :-----------: | :----------------------------------------------------------- |
-| **0xy** |   Arpeggio    | Plays 3 notes rapidly. x and y's values represent # of semitones above the original note. x is for the 2nd note, y is for the 3rd note. You should set the instrument when using this effect. |
+| **0xy** |   Arpeggio    | Plays 3 notes rapidly. x and y's values represent the number of semitones above the original note. x is for the 2nd note, y is for the 3rd note. You should set the instrument when using this effect. |
 | **Bxx** |     Jump      | Jump to specific pattern `xx`. Put this on the last heard note of a pattern. |
 | **Cxx** |    Volume     | Set the volume of a note to xx from `00` to `40`. A volume effect should be set on each new note since note volume is not reset in-game unlike most trackers' global volume setting. |
 | **Dxx** | Pattern break | Jumps to the next pattern early, where `xx` is the position (row) it should jump to in the next pattern. |


### PR DESCRIPTION
Hi, I did a lot of changes all at once to show people more GBT limitations earlier. I also added a section with youtube links that are really good resources for learning how to use trackers in general. I really would've liked to do all these changes it all little by little but I decided to just go for it. Lots of users of late have been asking a lot of common questions in the discord about speed and how to get started.

If there's something I should put back from the site's current version, please let me know, I hate messing with other people's work but I really wanted to make some of this stuff stand out so people don't skim over what was already in these docs.

CHANGELOG:

-Removed tracker tutorial from docs
-Added tutorial series links for tracker beginners
-Rewrote suggested program list to detail OS limits

-Moved important info earlier in the document such as:

the speed effect, not being able to edit instrument data, the 64 note limit, ending a pattern early, channel 1 needing c00 or a note to start, and volume parameter overwriting other effects

-Put all the instruments in tables
-Added hexadecimal numbers to the instrument list (I needed this so bad)
-Added a new section that explains speed and how tempo doesn't carry over in-game
-Added a section on volume limitations on a per-channel basis (thanks richardLulz for adding this info earlier!)
-Added deeper explanation to arpeggio effect
-Removed/changed some words in the effects and general tips lists because they were confusing
-Removed general tips that are now covered in their own respective sections/in #important limitations
-Removed the tip about setting note instrument/volume on every note because it's not required for channels 1 2 and 4 beyond the first note

-Disrupted order by making a huge amount of changes at once
-Probably changed some other things