### PR TITLE
Adding 2.0.0 collision/colorize tool info for Project-Editor.md and Keyboard-Shortcuts.md

### DIFF
--- a/content/docs/keyboard-shortcuts.md
+++ b/content/docs/keyboard-shortcuts.md
@@ -44,3 +44,37 @@ While editing the game world you can use the following keys to quickly manipulat
 **Eraser Mode** - E  
 **Collisions Mode** - C  
 **Set Player Start Position** - P (while hovering over desired location)
+
+## Drawing mode
+
+<span class="new">New in 2.0.0</span>
+
+Drawing mode is automatically enabled in the _Collision tool_ and the _Colorize tool_.
+
+**Drawing tools**  
+**8px Brush** - 8  
+**16px Brush** - 9  
+**Fill:** - 0  
+**Hide Triggers/Actors:** - -  
+
+## Collision types
+
+These are only availible when using the _Collision tool_.
+
+**Solid** - 1  
+**Collision Top** - 2  
+**Collision Bottom** - 3  
+**Collision Left** - 4  
+**Collision Right** - 5  
+**Ladder (Platformer only)** - 6  
+
+## Colorize palettes
+
+These are only availible when using the _Colorize tool_.
+
+**Use Palette 1** - 1  
+**Use Palette 2** - 2  
+**Use Palette 3** - 3  
+**Use Palette 4** - 4  
+**Use Palette 5** - 5  
+**Use Palette 6** - 6  

--- a/content/docs/keyboard-shortcuts.md
+++ b/content/docs/keyboard-shortcuts.md
@@ -45,19 +45,18 @@ While editing the game world you can use the following keys to quickly manipulat
 **Collisions Mode** - C  
 **Set Player Start Position** - P (while hovering over desired location)
 
-## Drawing mode
+## Drawing Mode
 
 <span class="new">New in 2.0.0</span>
 
 Drawing mode is automatically enabled in the _Collision tool_ and the _Colorize tool_.
 
-**Drawing tools**  
 **8px Brush** - 8  
 **16px Brush** - 9  
-**Fill:** - 0  
-**Hide Triggers/Actors:** - -  
+**Fill** - 0  
+**Hide Triggers/Actors** - -  
 
-## Collision types
+## Collision Types
 
 These are only availible when using the _Collision tool_.
 
@@ -68,7 +67,7 @@ These are only availible when using the _Collision tool_.
 **Collision Right** - 5  
 **Ladder (Platformer only)** - 6  
 
-## Colorize palettes
+## Colorize Palettes
 
 These are only availible when using the _Colorize tool_.
 

--- a/content/docs/keyboard-shortcuts.md
+++ b/content/docs/keyboard-shortcuts.md
@@ -51,29 +51,32 @@ While editing the game world you can use the following keys to quickly manipulat
 
 Drawing mode is automatically enabled in the _Collision tool_ and the _Colorize tool_.
 
+**Draw** - Click on scene  
+**Draw line from last point** - Click to set first point, hold shift, click to set next point  
+**Lock brush to axis** - Hold Shift + Hold Click  
 **8px Brush** - 8  
 **16px Brush** - 9  
 **Fill** - 0  
-**Hide Triggers/Actors** - -  
+**Hide Triggers/Actors** - -
 
 ## Collision Types
 
 These are only availible when using the _Collision tool_.
 
+Each tile can hold a maximum of 1 ladder and 3 collision sides. Ladders will not replace existing collision when placed on top of other colliders.
+
+**Select multiple collision types** - Shift + Click  
+**Erase collision tile** - Click on a collision tile  
 **Solid** - 1  
 **Collision Top** - 2  
 **Collision Bottom** - 3  
 **Collision Left** - 4  
 **Collision Right** - 5  
-**Ladder (Platformer only)** - 6  
+**Ladder (Platformer only)** - 6
 
 ## Colorize Palettes
 
 These are only availible when using the _Colorize tool_.
 
-**Use Palette 1** - 1  
-**Use Palette 2** - 2  
-**Use Palette 3** - 3  
-**Use Palette 4** - 4  
-**Use Palette 5** - 5  
-**Use Palette 6** - 6  
+**Change Brush Palette** - 1-6  
+**Change Palettes** - Hold click on existing palette

--- a/content/docs/project-editor.md
+++ b/content/docs/project-editor.md
@@ -13,6 +13,8 @@ Use the _Editor Tools_ to switch between Select, Add, Erase, Collision, and Colo
 
 By default, your project's properties are shown in the _Editor Sidebar_ on the right. Here you can set the project name and choose the starting scene. This project view is also where initial values for the Player actor are set. See the page on [The Player](/docs/player) for more information on the Player.
 
+To look at project properties again from the _Editor Sidebar_, click on any empty space between scenes.
+
 ## Editor Tools
 
 _Select tool:_ Clicking any scenes, actors, or triggers will update the _Editor Sidebar_ to show the properties and scripts for the item you selected. You can switch back to the Project's properties by clicking outside of a scene.
@@ -25,7 +27,7 @@ _Collision tool:_ Allows you to add collisions to any type of scene using GB Stu
 
 _Colorize tool:_ Allows each tile to be given a different palette to use in place of GB Studio's default palette. The _Colorize tool_ also uses GB Studio's _Drawing mode_. The palettes used here are determined in the _Palette_ tab in the _Project Editor_. Clicking this for the first time will prompt if you want to enable color for your project. Enabling color to your game will not break compatability with regular GB systems/emulators.
 
-To look at project properties again from the _Editor Sidebar_, click on any empty space between scenes.
+See the documentation on [Keyboard Shortcuts](/docs/keyboard-shortcuts) for editor tool shortcuts.
 
 ## The Asset Viewer
 
@@ -38,29 +40,3 @@ The _?_ button will bring up the documentation page for that type of asset. The 
 As with any window in GB Studio, your project assets folder can be opened with the folder button on the top right.
 
 See the documentation on [Assets](/docs/assets) for more information on how to add new assets.
-
-## Drawing mode Hotkeys
-
-Drawing mode is automatically enabled in _Collision mode_ and _Colorize mode_. Each hotkey can be previewed by hovering your mouse over the tool, collision-type or palette you want to use.
-
-**Tools**  
-- 8px Brush: 8
-- 16px Brush: 9
-- Fill: 0
-- Hide Triggers/Actors: -
-
-**Collision Types**  
-- Solid: 1
-- Collision Top: 2
-- Collision Bottom: 3
-- Collision Left: 4
-- Collision Right: 5
-- Ladder (Platformer only): 6
-
-**Colorize Palettes**  
-- Use Palette 1: 1
-- Use Palette 2: 2
-- Use Palette 3: 3
-- Use Palette 4: 4
-- Use Palette 5: 5
-- Use Palette 6: 6

--- a/content/docs/project-editor.md
+++ b/content/docs/project-editor.md
@@ -17,15 +17,15 @@ To look at project properties again from the _Editor Sidebar_, click on any empt
 
 ## Editor Tools
 
-_Select tool:_ Clicking any scenes, actors, or triggers will update the _Editor Sidebar_ to show the properties and scripts for the item you selected. You can switch back to the Project's properties by clicking outside of a scene.
+**Select tool:** Clicking any scenes, actors, or triggers will update the _Editor Sidebar_ to show the properties and scripts for the item you selected. You can switch back to the Project's properties by clicking outside of a scene.
 
-_Add tool:_ You are given the choice of adding a new Actor, Trigger or Scene. After clicking any of the 3 options, your mouse cursor will be loaded with a new item. You can place the new item by clicking inside the Project Editor, and cancel the action by pressing Escape or selecting another tool from _Editor Tools_.
+**Add tool:** You are given the choice of adding a new Actor, Trigger or Scene. After clicking any of the 3 options, your mouse cursor will be loaded with a new item. You can place the new item by clicking inside the Project Editor, and cancel the action by pressing Escape or selecting another tool from _Editor Tools_.
 
-_Erase tool:_ All collisions, actors, and triggers will be removed when clicked. Scenes are not affected by _Erase mode_. To delete a scene, use _Select mode_ and click the scene's background. In the _Editor Sidebar_ click the down arrow at the top to reveal the "Delete Scene" button. All erase actions can be undone by pressing Control Z.
+**Erase tool:** All collisions, actors, and triggers will be removed when clicked. Scenes are not affected by _Erase mode_. To delete a scene, use _Select mode_ and click the scene's background. In the _Editor Sidebar_ click the down arrow at the top to reveal the "Delete Scene" button. All erase actions can be undone by pressing Control Z.
 
-_Collision tool:_ Allows you to add collisions to any type of scene using GB Studio's _Drawing mode_.
+**Collision tool:** Allows you to add collisions to any type of scene using GB Studio's _Drawing mode_.
 
-_Colorize tool:_ Allows each tile to be given a different palette to use in place of GB Studio's default palette. The _Colorize tool_ also uses GB Studio's _Drawing mode_. The palettes used here are determined in the _Palette_ tab in the _Project Editor_. Clicking this for the first time will prompt if you want to enable color for your project. Enabling color to your game will not break compatability with regular GB systems/emulators.
+**Colorize tool:** Allows each tile to be given a different palette to use in place of GB Studio's default palette. The _Colorize tool_ also uses GB Studio's _Drawing mode_. The palettes used here are determined in the _Palette_ tab in the _Project Editor_.
 
 See the documentation on [Keyboard Shortcuts](/docs/keyboard-shortcuts) for editor tool shortcuts.
 
@@ -35,7 +35,9 @@ You can search and preview all the assets in your game by using the _Project Nav
 
 <img title="The Asset Viewer" src="/img/screenshots/asset-viewer.png" width="1258">
 
-The _?_ button will bring up the documentation page for that type of asset. The searchbar beside it can narrow down the list of assets to a specific file. Pressing _Edit_ will open the selected file using your system's default app setting.
+The **?** button will bring up the documentation page for that type of asset.  
+The searchbar will narrow down the list of assets to a specific file.  
+Pressing _Edit_ will open the selected file using your system's default app setting.  
 
 As with any window in GB Studio, your project assets folder can be opened with the folder button on the top right.
 

--- a/content/docs/project-editor.md
+++ b/content/docs/project-editor.md
@@ -5,18 +5,62 @@ next: "/docs/scenes"
 nextTitle: "Scenes"
 ---
 
-The default view for the _Project Editor_, as shown below, is the _Game World_. This is where you can create your game by combining scenes, adding actors and triggers then building scripting events to add interactions.
+The default view for the _Project Editor_ as shown below is the _Game World_. This is where you can create your game by combining scenes, adding actors and triggers then building scripting events to add interactions.
 
 <img title="The Project Editor" src="/img/screenshots/project-editor.png" width="1258">
 
-Use the _Editor Tools_ to switch between Select, Add, Erase and Collision Drawing modes.
+Use the _Editor Tools_ to switch between Select, Add, Erase, Collision, and Color Drawing modes.
 
-In the _Select mode_ clicking scenes, actors or triggers causes the _Editor Sidebar_ to show editable fields specific to whatever was selected. Clicking in the background between scenes switches the sidebar back to the _Project Editor_ where you can set the project name and choose the starting scene and position.
+By default, your project's properties are shown in the _Editor Sidebar_ on the right. Here you can set the project name and choose the starting scene. This project view is also where initial values for the Player actor are set. See the page on [The Player](/docs/player) for more information on the Player.
+
+## Editor Tools
+
+_Select tool:_ Clicking any scenes, actors, or triggers will update the _Editor Sidebar_ to show the properties and scripts for the item you selected. You can switch back to the Project's properties by clicking outside of a scene.
+
+_Add tool:_ You are given the choice of adding a new Actor, Trigger or Scene. After clicking any of the 3 options, your mouse cursor will be loaded with a new item. You can place the new item by clicking inside the Project Editor, and cancel the action by pressing Escape or selecting another tool from _Editor Tools_.
+
+_Erase tool:_ All collisions, actors, and triggers will be removed when clicked. Scenes are not affected by _Erase mode_. To delete a scene, use _Select mode_ and click the scene's background. In the _Editor Sidebar_ click the down arrow at the top to reveal the "Delete Scene" button. All erase actions can be undone by pressing Control Z.
+
+_Collision tool:_ Allows you to add collisions to any type of scene using GB Studio's _Drawing mode_.
+
+_Colorize tool:_ Allows each tile to be given a different palette to use in place of GB Studio's default palette. The _Colorize tool_ also uses GB Studio's _Drawing mode_. The palettes used here are determined in the _Palette_ tab in the _Project Editor_. Clicking this for the first time will prompt if you want to enable color for your project. Enabling color to your game will not break compatability with regular GB systems/emulators.
+
+To look at project properties again from the _Editor Sidebar_, click on any empty space between scenes.
 
 ## The Asset Viewer
 
-Using the _Project Navigator_ you can switch between the available views for your project. If you select _Sprites_, _Backgrounds_, _UI Elements_ or _Music_ you will be taken to the asset viewer where you can search and preview the assets available in your game.
+You can search and preview all the assets in your game by using the _Project Navigator_'s drop-down list. Selecting _Sprites_, _Backgrounds_, _UI Elements_ or _Music_ will bring up the asset viewer for each type of asset.
 
 <img title="The Asset Viewer" src="/img/screenshots/asset-viewer.png" width="1258">
 
-See the documentation on [Assets](/docs/assets) for more information on how to add new assets and the different requirements needed.
+The _?_ button will bring up the documentation page for that type of asset. The searchbar beside it can narrow down the list of assets to a specific file. Pressing _Edit_ will open the selected file using your system's default app setting.
+
+As with any window in GB Studio, your project assets folder can be opened with the folder button on the top right.
+
+See the documentation on [Assets](/docs/assets) for more information on how to add new assets.
+
+## Drawing mode Hotkeys
+
+Drawing mode is automatically enabled in _Collision mode_ and _Colorize mode_. Each hotkey can be previewed by hovering your mouse over the tool, collision-type or palette you want to use.
+
+**Tools**  
+- 8px Brush: 8
+- 16px Brush: 9
+- Fill: 0
+- Hide Triggers/Actors: -
+
+**Collision Types**  
+- Solid: 1
+- Collision Top: 2
+- Collision Bottom: 3
+- Collision Left: 4
+- Collision Right: 5
+- Ladder (Platformer only): 6
+
+**Colorize Palettes**  
+- Use Palette 1: 1
+- Use Palette 2: 2
+- Use Palette 3: 3
+- Use Palette 4: 4
+- Use Palette 5: 5
+- Use Palette 6: 6

--- a/content/docs/scenes.md
+++ b/content/docs/scenes.md
@@ -5,20 +5,46 @@ next: "/docs/player"
 nextTitle: "The Player"
 ---
 
-A scene is a single screen of your game, it can contain multiple [actors](/docs/actors) and [triggers](/docs/triggers). Your game will typically be made up of many scenes connected together with triggers using the _Change Scene_ event.
+A scene is a single screen of your game, it can contain multiple [actors](/docs/actors) and [triggers](/docs/triggers). A game is typically made-up of many scenes connected together with triggers using the _Change Scene_ event.
 
 ## Adding a Scene
 
-To add a scene to a scene click the _**+** button_ in the _Editor Tools_ and select _Scene_ from the menu (alternatively press the **S** key), then click on any empty space in the _Project Viewport_ where you wish to place the scene.
+Click the _**+** button_ in the _Editor Tools_ and select _Scene_ from the menu. Click on any empty space in the _Project Viewport_ to place the new scene.
 
 <img src="/img/screenshots/add-scene.gif" style="width:300px"/>
 
-When a scene has been added you can use the _Editor Sidebar_ to give the scene a name and to choose which background image from your project's assets that you want to use. See the documentation for [Backgrounds](/docs/backgrounds) for more information on adding background images.
+You can use the _Editor Sidebar_ to give your scene a name and a background from your project's assets. See the documentation for [Backgrounds](/docs/backgrounds) for more information on adding background images.
+
+## Scene Properties
+
+- **Name** - Names your scene. Useful for locating your scene with the search bar.
+- **Type** - Lets you choose from the list of gamemodes. A scene's type cannot be changed in-game.
+- **Background** - Lets you choose a background from the `assets/backgrounds` folder.
+- **Add Notes** - Adds an editor-only text field to your scene.
+
+## Navigation
+
+Navigation is a list that shows every Actor and Trigger inside the scene. Clicking any name in the list will select that object and show its properties in the _Editor Sidebar_.
 
 ## Scripting
 
-A scene _On Init_ script can be used to have events run as soon as the scene is loaded. When the scene is selected click the _Add Event button_ in the _Editor Sidebar_ to open the event menu and start building the script.
-
-If any actors in the scene also have _On Init_ scripts they will be executed first.
+To start building a script, select a scene and click the _Add Event button_ in the _Editor Sidebar_ to open the event menu. Select an event to add it to the script.
 
 For more information see the documentation for [Scripting](/docs/scripting).
+
+## Adding Collision to a Scene
+
+Select the _Collision Tool_ from the _Editor Tools_. There are 6 collision types that can be added.
+
+**Solid** Collision stops colliding actors from entering the tile on any side.  
+**Top/Bottom/Left/Right** collision stops colliding actors from entering the tile from that specific side. This is useful for one-way collision and semi-solid platforms.
+
+Each tile can hold a maximum of 1 ladder and 3 collision sides. Adding 4 collision sides will replace the sides with a single solid block. Ladders will not replace existing collision when placed on top of other collision.
+
+## Colorizing a Scene
+
+Select the _Colorizer Tool_ from the _Editor Tools_. There are 6 palettes types that can be added to a scene with Color Mode enabled. Palettes can be adjusted in Settings.
+
+The palettes used in the _Colorizer Tool_ can be swapped out for existing palettes (such as the UI palette) by long-clicking on a palette.
+
+For more information about the drawing mode used for the _Colorize Tool_ and the _Collision Tool_, see [Keyboard Shortcuts](/docs/keyboard-shortcuts).


### PR DESCRIPTION
I had a hard time knowing what to call the "tile-painting" mode but I noticed that it was previously mentioned as "drawing" so I just called it "drawing mode"

Also originally this page only talked about "Select mode" and I felt like that wasn't suitable for the fact that it came from the "Editor toolbar" so I've switched to calling it the "Select tool", "Add tool", "Collisions tool" - which now enables "drawing mode". I hope this wording makes enough sense, or if I'm secretly breaking a UX convention and I should revert what I did to the naming conventions.

I also hope you don't mind that I changed some of the old wording so the first parts of most sentences are about use case, rather than starting off as instructions that aren't made clear as to what they will be doing first.