### PR TITLE
Update "A: F: T:" limits in Scenes & Actors, ++ new Actor properties

### DIFF
--- a/content/docs/actors.md
+++ b/content/docs/actors.md
@@ -8,38 +8,70 @@ nextTitle: "Triggers"
 Actors are the characters and objects in your scene that you can interact with.
 
 ## Adding an Actor
-
 To add an actor to a scene click the _**+** button_ in the _Editor Tools_ and select _Actor_ from the menu (alternatively press the **A** key), then click on the scene and position where you wish to place the actor.
 
 <img src="/img/screenshots/add-actor.gif" style="width:300px"/>
 
-The _Editor Sidebar_ will switch to show the actor settings where you can give the actor a name for easier navigation later, reposition the actor (which you can also do with drag and drop), set the [sprite sheet](/docs/sprites), initial direction, the movement type and create a script that will play when the player interacts with the actor.
+## Setting a Sprite
+To add a sprite sheet to your actor, select your actor, and locate the drop-down menu for "Sprite Sheet" in the _Editor Sidebar_.
+
+To learn more about the different types of Sprites you can add to your actor, see the [Sprites](/docs/sprites) page.
+
+## Actor Properties
+Once an actor has been selected, the _Editor Sidebar_ will show the actor's properties. Here are the properties you can change in the _Editor Sidebar_:
+- Name
+- X and Y
+- Sprite Sheet
+- Movement Type (actor sprite sheets only)
+- Animate while stationary (animated actors only)
+- Animate by cycling frames (animated sprites/static actors only)
+- Direction (actor sprite sheets only)
+- Movement Speed
+- Animation Speed (animated actors/sprites only)
+- Collision Group
+- Add Notes
+- Navigation
+- Scripts
+
+Giving your actors a *name* helps organize them in your project. An actor's name will be visible in any drop-down menu that asks you to pick an actor, such as the *Actor: Hide* event.
+
+*X and Y* lets you set the actor's starting position. You can also click and drag an actor around with your mouse to move it.
+
+*Sprite Sheet* lets you change the look of your actor. Read more about the different sprite sheet types on the [Sprites](/docs/sprites) page.
+
+## Movement Types
+The _Movement Type_ property lets you change how an actor moves. The one you should use depends on how you want the actor to behave when the player walks around the scene and interacts with it. There are 4 movement types:
+- **Static** - The actor faces the same direction and stays in the same spot, unless it is told to change this with [Scripting Events](/docs/scripting).
+Useful for things like signposts or other stationary objects.
+- **Face Interaction** - The actor faces you when you interact with it. It does not move at random.
+Useful for simple characters to make them more responsive to the player's actions.
+- **Random Rotation** - The actor will start in the initial direction but will randomly change direction at set intervals.
+Useful to show characters who are looking around their surroundings.
+- **Random Movement** - The actor will randomly change direction and move around the scene at set intervals. Useful for characters who are searching an area. Actors can block the player's movement.
+
+_Note_ If the actor uses a static sprite sheet (containing only a single frame of animation) then the only movement type available will be static, and the menus for choosing the movement type and initial direction won't appear.
+
+_Animate while stationary_ is an option for actors with animated sprites. When used on the sample project actors, this creates a "running in place" effect. This is useful to make stationary actors more lively when combined with the _Face Interaction_ or _Random Rotation_ movement types.
+
+_Animate by cycling frames_ is an option for static actors and animated sprites. Checking this box will make the actor animate by default, and will grant them the _Animation Speed_ property as well.
+
+_Direction_ changes the starting direction of an actor. This is only available to actors with actor sprite sheets.
 
 ## Collision Groups
-
 Actors can be given a collision group in the _Editor Sidebar_. When enabled, the option to run scripts based on collisions will appear in the _Editor Sidebar_. To learn more about On Hit scripts, see the documentation for [Scripting](/docs/scripting).
 
-## Movement Type
+## Other Properties
+_Add Notes_ lets you write notes. These notes are only visible in GB Studio's _Editor Sidebar_ and can't be read in-game. This is identical to adding notes to scenes, triggers, and the project itself.
 
-There are a few different movement types available to choose, the one you should use will depend on how you want the actor to behave as the player is walking around the scene and interacting with it.
-
-- **Static** - The actor will display a single frame from the selected spritesheet.  
-  If the sprite sheet contains more than one frame you will be given the option to choose which frame to display, this can be modified later using an _Actor: Set Animation Frame_ event. Sprite sheets with multiple frames also enable the ability to optionally animate the actor by cycling through each of the frames at a specified speed, the speed can also be modified with an _Actor: Set Animation Speed_ event.\
-  \
-  The actor will only ever face in the initial direction (unless the direction is modified later using a script). If the player interacts with this actor it will not change direction. Useful for things like signposts or other stationary objects.
-
-- **Face Interaction** - The actor will start facing in the initial direction but when the player interacts with the actor it will turn to face the player before it's script plays. Useful for simple characters to make them more responsive to the player's actions.
-
-- **Random Rotation** - The actor will start in the initial direction but will randomly change direction at set intervals. Useful to show characters who are looking around their surroundings.
-
-- **Random Movement** - The actor will randomly change direction and move around the scene at set intervals. Useful for characters who are searching an area. Actors can block the player's movement so be careful not to use this movement type around tight spaces where the player might get stuck waiting for the actor to move out of the way.
-
-_Note_ If the actor uses a static sprite sheet (i.e. containing only a single frame of animation) then the only movement type available will be static and the inputs for choosing the movement type and initial direction won't appear.
-
-## Frame Limits
-
-Due to hardware limitations only **25 unique frames** of animation can be allocated to actors in each scene. Where possible use static or non animated sprite sheets to decrease the number of frames used. Another way to reduce the frame count is to reuse the same sprite for multiple actors in the scene, reusing the same sprite sheet will not count towards the scene frame total.
+_Navigation_ will show you the scene that your actor belongs to.
 
 ## Scripting
-
 To learn about how to script your Actor, see the documentation for [Scripting](/docs/scripting).
+
+## Actor Limits
+A maximum of 30 actors can be added to a scene. However, there can only be 10 actors visible on-screen at once. The screen is defined as a ``160px x 144px`` boundary. Read more about Actor Limits on the [Scenes](/docs/scenes/#Actor-Limits) page.
+
+## Frame Limits
+Due to hardware limitations only **25 unique frames** of animation can be allocated to actors in each scene. The limit on unique sprite frames is shared between all actors. When a scene has actors that use more than 25 unique sprite frames, some actors and UI elements may appear glitchy.
+
+To stay under the 25 unique frame limit, use static or non animated sprite sheets when possible. You can also reuse the same sprite for multiple actors in the scene - reusing the same sprite sheet will not count towards the scene frame total.

--- a/content/docs/actors.md
+++ b/content/docs/actors.md
@@ -31,25 +31,27 @@ These are properties that apply to all actors:
 - Navigation
 - Scripts
 
-#### Name
+### Name
 Giving your actors a *name* helps organize them in your project. An actor's name will be visible in any drop-down menu that asks you to pick an actor, such as the *Actor: Hide* event.
 
-#### Position
-Your actor's _Position_ or _X and Y_ let you set the actor's starting position on the screen. X starts at zero from the left side of the scene and increases as your actor goes right. Y starts at zero from the top of the scene and increases as your actor goes down. You can also click and drag an actor around with your mouse to move it.
+### Position
+Your actor's _Position_ or _X and Y_ let you set the actor's starting position on the screen.  
+X starts at zero from the left side of the scene and increases as your actor goes right.  
+Y starts at zero from the top of the scene and increases as your actor goes down.
 
-_Note_ You can press ``P`` to move your player's starting position to your mouse cursor.
+You can also click and drag an actor around with your mouse to move it.
 
-#### Sprite Sheet
+### Sprite Sheet
 The *Sprite Sheet* property lets you change the look of your actor. Read more about the different sprite sheet types on the [Sprites](/docs/sprites) page.
 
-#### Pin to Screen
+### Pin to Screen
 When an actor is pinned, the actor will not move without a script, and does not create collisions with other actors in your scene.
 
 Enabling this property will temporarily change your scene to be blacked-out, with a ``160px x 144px`` boundary in the top-left corner showing part of your original scene. Use your mouse to drag the actor to where you want it to be pinned to the screen. 
 
 Select a different actor, the scene, or the project to return the blacked-out view of your scene to normal.
 
-#### Collision Groups
+### Collision Groups
 Actors can be given a collision group in the _Editor Sidebar_. When enabled, the option to run scripts based on collisions will appear in the _Editor Sidebar_. To learn more about On Hit scripts, see the documentation for [Scripting](/docs/scripting).
 
 ## Movement and Animation Properties
@@ -74,48 +76,52 @@ _Animated Actor Sprite Sheets_ have 6 frames of animation, adding a 2nd frame to
 
 You can read more about adding a specific type of sprite sheet on the [Sprites](/docs/sprites) page.
 
-### Movement Types
+## Movement Types
 The _Movement Type_ property lets you change how an actor moves. The one you should use depends on how you want the actor to behave when the player walks around the scene and interacts with it. There are 4 movement types:
-- **Static** - The actor faces the same direction and stays in the same spot, unless it is told to change this with [Scripting Events](/docs/scripting).
+- **Static** - The actor faces the same direction and stays in the same spot, unless it is told to move with [Scripting Events](/docs/scripting).  
 Useful for things like signposts or other stationary objects.
-- **Face Interaction** - The actor faces you when you interact with it. It does not move at random.
+- **Face Interaction** - The actor faces you when you interact with it. It does not move at random.  
 Useful for simple characters to make them more responsive to the player's actions.
-- **Random Rotation** - The actor will start in the initial direction but will randomly change direction at set intervals.
+- **Random Rotation** - The actor will start in the initial direction but will randomly change direction at set intervals.  
 Useful to show characters who are looking around their surroundings.
-- **Random Movement** - The actor will randomly change direction and move around the scene at set intervals. Useful for characters who are searching an area. Actors can block the player's movement.
+- **Random Movement** - The actor will randomly change direction and move around the scene at set intervals.  
+Useful for characters who are searching an area. Actors can block the player's movement.
 
-#### Animation Speed
+### Animation Speed
 Animation speed changes how fast an animation is played back, from Speed 0 (Slower) to Speed 4 (Faster). Animation speed can also be set to "None" to prevent an actor from animating at all, even if they would normally animate from walking or changing direction.
 
-#### Animate while stationary / Animate by cycling frames
+### Animate while stationary / Animate by cycling frames
 These two properties are checkboxes that appear in the same place. Your actor will animate on its own when this property is enabled.
 
 For animated actor sprite sheets, "Animate while stationary" will play the two frames of the current direction they're facing. This creates a "running in place" effect.
 
 For other animated actors, "Animate by cycling frames" will run through its sprite sheet in a loop. The Animation Speed property becomes visible on the _Editor Sidebar_ when this property is enabled.
 
-#### Direction
+### Direction
 _Direction_ changes the starting direction of an actor. This is only available to actors with actor-type sprite sheets.
 
-#### Sprite Type
+### Sprite Type
 The actor's _Sprite Type_ property is a way to override the sprite sheet type without changing the sprite sheet asset itself. The current options for sprite type are:
 - Static
 - Actor
 
 _Note_ If the actor uses a static sprite sheet (containing only a single frame of animation) then the only movement type available will be static, and the menus for choosing the movement type and initial direction won't appear.
 
-#### Initial Frame
+### Initial Frame
 This is the starting frame of an actor's animation, or the frame to display on a static actor.
 
-### Other Properties
+## Other Properties
 _Add Notes_ lets you write notes. These notes are only visible in GB Studio's _Editor Sidebar_ and can't be read in-game. This is identical to adding notes to scenes, triggers, and the project itself.
 
 _Navigation_ will show you the scene that your actor belongs to.
 
 _Scripting_ lets you make your actor respond to interactions with scripted events. To learn about how to script your actor, see the documentation for [Scripting](/docs/scripting).
 
+# Limits
+There are limits to how actors and their sprites can be used in GB Studio. These limits are to make sure your game appears as intended, as well as to keep your actor logic running smoothly.
+
 ## Actor Limits
-A maximum of 30 actors can be added to a scene. However, there can only be 10 actors visible on-screen at once. The screen is defined as a ``160px x 144px`` boundary. Read more about Actor Limits on the [Scenes](/docs/scenes/#Actor-Limits) page.
+A maximum of 30 actors can be added to a scene. However, there can only be 10 actors visible on-screen at once. The screen space is defined as a ``20 x 18`` tile boundary, equivalent to ``160px x 144px``. Read more about Actor Limits on the [Scenes](/docs/scenes/#Actor-Limits) page.
 
 ## Frame Limits
 Due to hardware limitations only **25 unique frames** of animation can be allocated to actors in each scene. The limit on unique sprite frames is shared between all actors. When a scene has actors that use more than 25 unique sprite frames, some actors and UI elements may appear glitchy.

--- a/content/docs/actors.md
+++ b/content/docs/actors.md
@@ -17,29 +17,64 @@ To add a sprite sheet to your actor, select your actor, and locate the drop-down
 
 To learn more about the different types of Sprites you can add to your actor, see the [Sprites](/docs/sprites) page.
 
-## Actor Properties
-Once an actor has been selected, the _Editor Sidebar_ will show the actor's properties. Here are the properties you can change in the _Editor Sidebar_:
+# Actor Properties
+Once an actor has been selected, the _Editor Sidebar_ will show the actor's properties.
+
+## General Properties
+These are properties that apply to all actors:
 - Name
-- X and Y
+- X and Y (Position)
 - Sprite Sheet
-- Movement Type (actor sprite sheets only)
-- Animate while stationary (animated actors only)
-- Animate by cycling frames (animated sprites/static actors only)
-- Direction (actor sprite sheets only)
-- Movement Speed
-- Animation Speed (animated actors/sprites only)
+- Pin to Screen
 - Collision Group
 - Add Notes
 - Navigation
 - Scripts
 
+#### Name
 Giving your actors a *name* helps organize them in your project. An actor's name will be visible in any drop-down menu that asks you to pick an actor, such as the *Actor: Hide* event.
 
-*X and Y* lets you set the actor's starting position. You can also click and drag an actor around with your mouse to move it.
+#### Position
+Your actor's _Position_ or _X and Y_ let you set the actor's starting position on the screen. X starts at zero from the left side of the scene and increases as your actor goes right. Y starts at zero from the top of the scene and increases as your actor goes down. You can also click and drag an actor around with your mouse to move it.
 
-*Sprite Sheet* lets you change the look of your actor. Read more about the different sprite sheet types on the [Sprites](/docs/sprites) page.
+_Note_ You can press ``P`` to move your player's starting position to your mouse cursor.
 
-## Movement Types
+#### Sprite Sheet
+The *Sprite Sheet* property lets you change the look of your actor. Read more about the different sprite sheet types on the [Sprites](/docs/sprites) page.
+
+#### Pin to Screen
+When an actor is pinned, the actor will not move without a script, and does not create collisions with other actors in your scene.
+
+Enabling this property will temporarily change your scene to be blacked-out, with a ``160px x 144px`` boundary in the top-left corner showing part of your original scene. Use your mouse to drag the actor to where you want it to be pinned to the screen. 
+
+Select a different actor, the scene, or the project to return the blacked-out view of your scene to normal.
+
+#### Collision Groups
+Actors can be given a collision group in the _Editor Sidebar_. When enabled, the option to run scripts based on collisions will appear in the _Editor Sidebar_. To learn more about On Hit scripts, see the documentation for [Scripting](/docs/scripting).
+
+## Movement and Animation Properties
+The following properties change your actor's animation and world-interaction logic:
+
+- Movement Speed
+- Movement Type (for actor sprite sheets)
+- Animation Speed (for all animated sprites)
+- Animate while stationary / Animate by cycling frames
+- Initial Frame
+- Direction (for actor sprite sheets)
+- Sprite Type (for all animated sprites)
+
+*Movement Speed* changes how fast an actor moves. The speed can be changed from Speed 1/2 (Slower) to Speed 4 (Faster). A static actor can still be moved using [scripted events.](/docs/scripting)
+
+Most of the properties here are only available to some actors, depending on the type of sprite sheet they use. There are four types of sprite sheets:
+
+_Static Sprites_ have 1 frame of animation. This is the only non-animated sprite sheet type.  
+_Animated Sprites_ have anywhere from 2 to 25 frames of animation. No directions are associated with its frames.  
+_Actor Sprite Sheets_ have 3 frames of animation: One to face up, one to face down, and one for facing right.  
+_Animated Actor Sprite Sheets_ have 6 frames of animation, adding a 2nd frame to each direction of a regular Actor Sprite Sheet.  
+
+You can read more about adding a specific type of sprite sheet on the [Sprites](/docs/sprites) page.
+
+### Movement Types
 The _Movement Type_ property lets you change how an actor moves. The one you should use depends on how you want the actor to behave when the player walks around the scene and interacts with it. There are 4 movement types:
 - **Static** - The actor faces the same direction and stays in the same spot, unless it is told to change this with [Scripting Events](/docs/scripting).
 Useful for things like signposts or other stationary objects.
@@ -49,24 +84,35 @@ Useful for simple characters to make them more responsive to the player's action
 Useful to show characters who are looking around their surroundings.
 - **Random Movement** - The actor will randomly change direction and move around the scene at set intervals. Useful for characters who are searching an area. Actors can block the player's movement.
 
+#### Animation Speed
+Animation speed changes how fast an animation is played back, from Speed 0 (Slower) to Speed 4 (Faster). Animation speed can also be set to "None" to prevent an actor from animating at all, even if they would normally animate from walking or changing direction.
+
+#### Animate while stationary / Animate by cycling frames
+These two properties are checkboxes that appear in the same place. Your actor will animate on its own when this property is enabled.
+
+For animated actor sprite sheets, "Animate while stationary" will play the two frames of the current direction they're facing. This creates a "running in place" effect.
+
+For other animated actors, "Animate by cycling frames" will run through its sprite sheet in a loop. The Animation Speed property becomes visible on the _Editor Sidebar_ when this property is enabled.
+
+#### Direction
+_Direction_ changes the starting direction of an actor. This is only available to actors with actor-type sprite sheets.
+
+#### Sprite Type
+The actor's _Sprite Type_ property is a way to override the sprite sheet type without changing the sprite sheet asset itself. The current options for sprite type are:
+- Static
+- Actor
+
 _Note_ If the actor uses a static sprite sheet (containing only a single frame of animation) then the only movement type available will be static, and the menus for choosing the movement type and initial direction won't appear.
 
-_Animate while stationary_ is an option for actors with animated sprites. When used on the sample project actors, this creates a "running in place" effect. This is useful to make stationary actors more lively when combined with the _Face Interaction_ or _Random Rotation_ movement types.
+#### Initial Frame
+This is the starting frame of an actor's animation, or the frame to display on a static actor.
 
-_Animate by cycling frames_ is an option for static actors and animated sprites. Checking this box will make the actor animate by default, and will grant them the _Animation Speed_ property as well.
-
-_Direction_ changes the starting direction of an actor. This is only available to actors with actor sprite sheets.
-
-## Collision Groups
-Actors can be given a collision group in the _Editor Sidebar_. When enabled, the option to run scripts based on collisions will appear in the _Editor Sidebar_. To learn more about On Hit scripts, see the documentation for [Scripting](/docs/scripting).
-
-## Other Properties
+### Other Properties
 _Add Notes_ lets you write notes. These notes are only visible in GB Studio's _Editor Sidebar_ and can't be read in-game. This is identical to adding notes to scenes, triggers, and the project itself.
 
 _Navigation_ will show you the scene that your actor belongs to.
 
-## Scripting
-To learn about how to script your Actor, see the documentation for [Scripting](/docs/scripting).
+_Scripting_ lets you make your actor respond to interactions with scripted events. To learn about how to script your actor, see the documentation for [Scripting](/docs/scripting).
 
 ## Actor Limits
 A maximum of 30 actors can be added to a scene. However, there can only be 10 actors visible on-screen at once. The screen is defined as a ``160px x 144px`` boundary. Read more about Actor Limits on the [Scenes](/docs/scenes/#Actor-Limits) page.

--- a/content/docs/scenes.md
+++ b/content/docs/scenes.md
@@ -8,7 +8,6 @@ nextTitle: "The Player"
 A scene is a single screen of your game, it can contain multiple [actors](/docs/actors) and [triggers](/docs/triggers). A game is typically made-up of many scenes connected together with triggers using the _Change Scene_ event.
 
 ## Adding a Scene
-
 Click the _**+** button_ in the _Editor Tools_ and select _Scene_ from the menu. Click on any empty space in the _Project Viewport_ to place the new scene.
 
 <img src="/img/screenshots/add-scene.gif" style="width:300px"/>
@@ -16,24 +15,20 @@ Click the _**+** button_ in the _Editor Tools_ and select _Scene_ from the menu.
 You can use the _Editor Sidebar_ to give your scene a name and a background from your project's assets. See the documentation for [Backgrounds](/docs/backgrounds) for more information on adding background images.
 
 ## Scene Properties
-
 - **Name** - Names your scene. Useful for locating your scene with the search bar.
 - **Type** - Lets you choose from the list of gamemodes. A scene's type cannot be changed in-game.
 - **Background** - Lets you choose a background from the `assets/backgrounds` folder.
 - **Add Notes** - Adds an editor-only text field to your scene.
 
 ## Navigation
-
 Navigation is a list that shows every Actor and Trigger inside the scene. Clicking any name in the list will select that object and show its properties in the _Editor Sidebar_.
 
 ## Scripting
-
 To start building a script, select a scene and click the _Add Event button_ in the _Editor Sidebar_ to open the event menu. Select an event to add it to the script.
 
 For more information see the documentation for [Scripting](/docs/scripting).
 
 ## Adding Collision to a Scene
-
 Select the _Collision Tool_ from the _Editor Tools_. There are 6 collision types that can be added.
 
 **Solid** Collision stops colliding actors from entering the tile on any side.  
@@ -42,9 +37,29 @@ Select the _Collision Tool_ from the _Editor Tools_. There are 6 collision types
 Each tile can hold a maximum of 1 ladder and 3 collision sides. Adding 4 collision sides will replace the sides with a single solid block. Ladders will not replace existing collision when placed on top of other collision.
 
 ## Colorizing a Scene
-
 Select the _Colorizer Tool_ from the _Editor Tools_. There are 6 palettes types that can be added to a scene with Color Mode enabled. Palettes can be adjusted in Settings.
 
 The palettes used in the _Colorizer Tool_ can be swapped out for existing palettes (such as the UI palette) by long-clicking on a palette.
 
 For more information about the drawing mode used for the _Colorize Tool_ and the _Collision Tool_, see [Keyboard Shortcuts](/docs/keyboard-shortcuts).
+
+## Scene Limits
+There are several limits that GB Studio has put in place to keep game performance consistent, and to minimize visual bugs.
+
+Each scene can have a maxmimum of 30 actors, 25 unique actor sprite frames, and 30 triggers. You can check this information by selecting a scene and looking for the gray bar under your scene that reads: ``A: 0/30 F: 0/25 T: 0/30``. The letters on this bar represent the following:
+- ``A:`` represents the number of actors that the scene is using.
+- ``F:`` represents the number of unique frames that each actor is using in their sprite sheet.
+- ``T:`` represents the number of triggers that the scene isusing.
+
+### Actor Limits
+Each scene can have a maximum of 30 actors. Ideally, there should never be more than 10 actors within a ``160px x 144px`` boundary. Clustering more than 10 actors together in a scene will cause some actors to become invisible in-game. GB Studio will warn you if it thinks this will be the case for a scene:  
+
+<img src ="https://user-images.githubusercontent.com/16776042/94731004-03c44100-035c-11eb-917f-c0589052e604.png" style="width:300px"/>  
+
+You can address this message by moving or deleting actors so no more than 10 will be seen in a ``160px x 144px`` boundary. You can use the [Eraser Tool](/docs/keyboard-shortcuts/#Game-World) to delete actors. Actors will still become invisible if more than 10 actors move into the screenspace after the scene starts.
+
+### Frame Limits
+Each scene can have a maximum of 25 unique sprite frames. Read more about frame limits on the [Actors](/docs/actors/#Frame-Limits) page.
+
+### Trigger Limits
+Each scene can have a maximum of 30 triggers. Each trigger has its collision checked actively during gameplay, even when it's not being touched. Performance issues start to arise above 30 triggers. You can use the [Eraser Tool](/docs/keyboard-shortcuts/#Game-World) to delete triggers.

--- a/content/docs/scenes.md
+++ b/content/docs/scenes.md
@@ -52,11 +52,11 @@ Each scene can have a maxmimum of 30 actors, 25 unique actor sprite frames, and 
 - ``T:`` represents the number of triggers that the scene isusing.
 
 ### Actor Limits
-Each scene can have a maximum of 30 actors. Ideally, there should never be more than 10 actors within a ``160px x 144px`` boundary. Clustering more than 10 actors together in a scene will cause some actors to become invisible in-game. GB Studio will warn you if it thinks this will be the case for a scene:  
+Each scene can have a maximum of 30 actors. Ideally, there should never be more than 10 actors within a 20 x 18 tile boundary, equivalent to ``160px x 144px``. Clustering more than 10 actors together in a scene will cause some actors to become invisible in-game. GB Studio will warn you if it thinks this will be the case for a scene:  
 
 <img src ="https://user-images.githubusercontent.com/16776042/94731004-03c44100-035c-11eb-917f-c0589052e604.png" style="width:300px"/>  
 
-You can address this message by moving or deleting actors so no more than 10 will be seen in a ``160px x 144px`` boundary. You can use the [Eraser Tool](/docs/keyboard-shortcuts/#Game-World) to delete actors. Actors will still become invisible if more than 10 actors move into the screenspace after the scene starts.
+You can address this message by moving or deleting actors so no more than 10 will be seen in a 20 x 18 tile boundary. You can use the [Eraser Tool](/docs/keyboard-shortcuts/#Game-World) to delete actors. Actors will still become invisible if more than 10 actors move into the screenspace after the scene starts.
 
 ### Frame Limits
 Each scene can have a maximum of 25 unique sprite frames. Read more about frame limits on the [Actors](/docs/actors/#Frame-Limits) page.


### PR DESCRIPTION
I knew that the actor limits had to be mentioned/updated since we bumped the max actors number up to 30, but always with the stipulation that there could only be 10 on-screen at a time. That was something I felt was important to reiterate on the actors and scenes page.

Also, a comprehensive list of all properties was sorely missing from the docs, so I've reordered things around a bit. I figure this list could eventually be replaced with some graphic. **If Chris or someone else familiar with these docs can show me the best way to upload/link to images in these docs, that information would be super useful to me.**

I'm going to make one more commit to this as soon as I figure out how to explain what "pin to screen" does to complete the actor property suite, and also to tidy up some formatting stuff. I can't see what the formatting really looks like until the pull request is made, so excuse me for a few minutes here.

